### PR TITLE
fix(postiz-stack): fix Ollama workflow body serialization and resourc…

### DIFF
--- a/services/automation/postiz-stack/docker-compose.yml
+++ b/services/automation/postiz-stack/docker-compose.yml
@@ -198,6 +198,9 @@ services:
       - HOST_HOSTNAME=${HOST_HOSTNAME}
       - HOST_CONTAINERNAME=ollama-postiz
       - OLLAMA_KEEP_ALIVE=5m
+      - OLLAMA_MAX_LOADED_MODELS=1
+      - OLLAMA_NUM_PARALLEL=1
+      - OLLAMA_MAX_QUEUE=1
     volumes:
       - ${APPDATA_PATH}/postiz-stack/ollama:/root/.ollama
     extra_hosts:
@@ -211,11 +214,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4.0"
-          memory: 8G
+          cpus: "2.0"
+          memory: 3G
         reservations:
-          cpus: "1.0"
-          memory: 2G
+          cpus: "0.5"
+          memory: 1G
     networks:
       - internal_net
 

--- a/services/automation/postiz-stack/workflows/workflow_a_cron_generator.json
+++ b/services/automation/postiz-stack/workflows/workflow_a_cron_generator.json
@@ -64,11 +64,26 @@
     },
     {
       "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const input = $input.first().json;\nconst listings = input.results || input;\nconst body = JSON.stringify({\n  model: 'qwen2.5:1.5b',\n  stream: false,\n  prompt: 'You are a social media copywriter. Draft a high-performing caption for Etsy listing data: ' + JSON.stringify(listings)\n});\nreturn [{ json: { ollamaBody: body } }];"
+      },
+      "id": "prepare_ollama_body",
+      "name": "Prepare Ollama Body",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        710,
+        280
+      ]
+    },
+    {
+      "parameters": {
         "method": "POST",
         "url": "http://ollama:11434/api/generate",
         "sendBody": true,
-        "contentType": "json",
-        "jsonBody": "={\n  \"model\": \"llama3:8b\",\n  \"stream\": false,\n  \"prompt\": \"You are a social media copywriter. Draft a high-performing caption for Etsy listing data: \" + JSON.stringify($json.results || $json)\n}",
+        "contentType": "raw",
+        "rawContentType": "application/json",
+        "body": "={{$json.ollamaBody}}",
         "options": {
           "response": {
             "response": {
@@ -82,7 +97,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        710,
+        960,
         280
       ]
     },
@@ -117,7 +132,7 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        970,
+        1220,
         280
       ]
     },
@@ -135,7 +150,7 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        1230,
+        1480,
         280
       ],
       "credentials": {
@@ -157,7 +172,7 @@
       "type": "n8n-nodes-base.wait",
       "typeVersion": 1.1,
       "position": [
-        1490,
+        1740,
         280
       ]
     },
@@ -180,7 +195,7 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        1760,
+        2010,
         280
       ]
     }
@@ -198,6 +213,17 @@
       ]
     },
     "Fetch Etsy Active Listings": {
+      "main": [
+        [
+          {
+            "node": "Prepare Ollama Body",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Ollama Body": {
       "main": [
         [
           {


### PR DESCRIPTION
…e limits

- Add Code node to prepare Ollama request body in plain JS, avoiding n8n HTTP Request expression evaluation quirks that mangled model name
- Switch Ollama model from llama3:8b to qwen2.5:1.5b (~1.1GB vs ~4.7GB) to prevent OOM killing the host on inference
- Add OLLAMA_MAX_LOADED_MODELS, NUM_PARALLEL, MAX_QUEUE env vars to cap peak memory spikes during generation
- Lower Ollama container memory limit from 8G to 3G as a hard ceiling
- Pass ETSY_SHOP_ID, ETSY_CLIENT_ID, TELEGRAM_APPROVAL_CHAT_ID through to n8n container so $env expressions resolve at runtime