### PR TITLE
fix: stop Renovate from rate-limiting its own weekly PR run

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
   ],
   "branchPrefix": "renovate/",
   "timezone": "UTC",
+  "prHourlyLimit": 0,
   "baseBranchPatterns": [
     "main"
   ],

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,10 +17,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Renovate
-        uses: renovatebot/github-action@v39.1.3
+        uses: renovatebot/github-action@v46.1.19
         env:
           LOG_LEVEL: debug
           RENOVATE_LOG_LEVEL: debug
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_HOST_RULES: >-
+            [{"hostType":"docker","matchHost":"docker.io","username":"${{ secrets.DOCKER_HUB_USERNAME }}","password":"${{ secrets.DOCKER_HUB_PASSWORD }}"}]
         with:
           token: ${{ secrets.RENOVATE_TOKEN || secrets.GH_TOKEN || github.token }}


### PR DESCRIPTION
## Summary
Investigated the Renovate job at [run 29681927875 / job 88179482749](https://github.com/justinmpowers/unraid/actions/runs/29681927875/job/88179482749) and fixed the two real issues found:

- **PR/branch rate limiting**: Renovate's default `prHourlyLimit` is 2. The log showed grouped updates hitting `pr-limit-reached` / `branch-limit-reached` (`"hourlyPrLimit": 2`) every run. Since this workflow only runs once a week (`cron: '0 9 * * SUN'`), that throttle just deferred updates a full week for no benefit — set `prHourlyLimit: 0`.
- **Docker Hub 429s during dependency lookups**: anonymous pull rate limit was hit against `hub.docker.com`/`index.docker.io` while resolving image tags (one queue wait was 60s). Wired up `RENOVATE_HOST_RULES` using the existing `DOCKER_HUB_USERNAME`/`DOCKER_HUB_PASSWORD` secrets (already used by `check-updates.yml` for the same purpose) to authenticate those lookups.
- **Stale action pin**: `renovatebot/github-action` was pinned to `v39.1.3`, 7 majors behind current (`v46.1.19`), which also explains the Node 20 deprecation warning in the log.

Not touched (flagged but out of scope): a cosmetic WARN about the default `gitAuthor` email (Mend "Vigilant Mode" unsigned-commit flag), and routine debug-level skips for images tagged with epoch timestamps (`postiz-app`, old `n8n` tags) exceeding `maxMajorIncrement` — expected behavior, not a bug.

## Test plan
- [x] `.github/renovate.json` validated as valid JSON
- [x] `.github/workflows/renovate.yml` validated as valid YAML
- [ ] Trigger the Renovate workflow manually (`workflow_dispatch`) and confirm in the run log that all grouped updates get PRs/branches in one pass, and no `429` errors appear for Docker Hub lookups